### PR TITLE
Extract toolspec to pkg/toolspec shared library

### DIFF
--- a/api/run_specs.go
+++ b/api/run_specs.go
@@ -9,13 +9,13 @@ import (
 	"github.com/hydrocode-de/gorun/internal/cache"
 	"github.com/hydrocode-de/gorun/internal/db"
 	"github.com/hydrocode-de/gorun/internal/tool"
-	"github.com/hydrocode-de/gorun/internal/toolSpec"
+	"github.com/hydrocode-de/gorun/pkg/toolspec"
 	"github.com/spf13/viper"
 )
 
 type ListToolSpecResponse struct {
 	Count int                 `json:"count"`
-	Tools []toolSpec.ToolSpec `json:"tools"`
+	Tools []toolspec.ToolSpec `json:"tools"`
 }
 
 type CreateRunPayload struct {

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -1,43 +1,43 @@
 package cache
 
 import (
-	"github.com/hydrocode-de/gorun/internal/toolSpec"
+	"github.com/hydrocode-de/gorun/pkg/toolspec"
 )
 
 type Cache struct {
-	images      map[string]toolSpec.SpecFile
-	tools       map[string]toolSpec.ToolSpec
+	images      map[string]toolspec.SpecFile
+	tools       map[string]toolspec.ToolSpec
 	Initialised bool
 }
 
-func (c *Cache) GetToolSpec(key string) (*toolSpec.ToolSpec, bool) {
+func (c *Cache) GetToolSpec(key string) (*toolspec.ToolSpec, bool) {
 	spec, ok := c.tools[key]
 	return &spec, ok
 }
 
-func (c *Cache) SetToolSpec(key string, spec *toolSpec.ToolSpec) {
+func (c *Cache) SetToolSpec(key string, spec *toolspec.ToolSpec) {
 	c.tools[key] = *spec
 }
 
-func (c *Cache) ListToolSpecs() []toolSpec.ToolSpec {
-	specs := make([]toolSpec.ToolSpec, 0)
+func (c *Cache) ListToolSpecs() []toolspec.ToolSpec {
+	specs := make([]toolspec.ToolSpec, 0)
 	for _, spec := range c.tools {
 		specs = append(specs, spec)
 	}
 	return specs
 }
 
-func (c *Cache) GetImageSpec(key string) (*toolSpec.SpecFile, bool) {
+func (c *Cache) GetImageSpec(key string) (*toolspec.SpecFile, bool) {
 	spec, ok := c.images[key]
 	return &spec, ok
 }
 
-func (c *Cache) SetImageSpec(key string, spec toolSpec.SpecFile) {
+func (c *Cache) SetImageSpec(key string, spec toolspec.SpecFile) {
 	c.images[key] = spec
 }
 
 func (c *Cache) Reset() {
-	c.tools = make(map[string]toolSpec.ToolSpec)
-	c.images = make(map[string]toolSpec.SpecFile)
+	c.tools = make(map[string]toolspec.ToolSpec)
+	c.images = make(map[string]toolspec.SpecFile)
 	c.Initialised = false
 }

--- a/internal/tool/create.go
+++ b/internal/tool/create.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hydrocode-de/gorun/internal/files"
 	"github.com/hydrocode-de/gorun/internal/helper"
 	"github.com/hydrocode-de/gorun/internal/toolImage"
+	"github.com/hydrocode-de/gorun/pkg/toolspec"
 	"github.com/spf13/viper"
 )
 
@@ -21,12 +22,6 @@ type CreateRunOptions struct {
 	Parameters map[string]interface{}
 	Datasets   map[string]string
 }
-
-type ToolInput struct {
-	Parameters map[string]interface{} `json:"parameters"`
-	Datasets   map[string]string      `json:"data"`
-}
-type inputFile map[string]ToolInput
 
 func CreateToolRun(ctx context.Context, mountStrategy string, opts CreateRunOptions, user_id string) (db.Run, error) {
 	DB := viper.Get("db").(*db.Queries)
@@ -54,8 +49,8 @@ func CreateToolRun(ctx context.Context, mountStrategy string, opts CreateRunOpti
 	}
 
 	// create the input file
-	inputJSON, err := json.MarshalIndent(inputFile{
-		opts.Name: {
+	inputJSON, err := json.MarshalIndent(toolspec.InputFile{
+		opts.Name: toolspec.ToolInput{
 			Parameters: opts.Parameters,
 			Datasets:   datasets,
 		},

--- a/pkg/toolspec/VALIDATION.md
+++ b/pkg/toolspec/VALIDATION.md
@@ -1,0 +1,105 @@
+# Missing Validation Logic
+
+This document describes the validation logic that needs to be implemented for the `toolspec` package. This validation is required for both the `gorun` application and future container shim tools.
+
+## Parameter Validation
+
+### Type Validation
+Validate that parameter values match their declared types:
+- `string`: Must be a string value
+- `integer`: Must be an integer number (no decimal part)
+- `float`: Must be a numeric value (can have decimal part)
+- `boolean`: Must be a boolean value (true/false)
+- `datetime`: Must be a valid datetime string (ISO 8601 format recommended)
+- `enum`: Must be one of the values in the `Values` slice
+
+### Array Type Validation
+When `IsArray` is `true`:
+- Value must be an array/slice
+- Each element in the array must pass type validation
+- Empty arrays should be validated based on `Optional` flag
+
+### Range Validation
+For numeric types (`integer`, `float`):
+- If `Min` is set, value must be >= `Min`
+- If `Max` is set, value must be <= `Max`
+- Both `Min` and `Max` can be set to create a range
+
+### Enum Value Validation
+When `ToolType` is `enum`:
+- Value must be present in the `Values` slice
+- Case-sensitive matching (or define case-insensitive option)
+
+### Required Field Validation
+- If `Optional` is `false` (or not set), the parameter must be provided
+- If `Optional` is `true`, the parameter can be omitted
+- When omitted, `Default` value should be used if provided
+
+### Default Value Handling
+- If a parameter is not provided and has a `Default` value, use the default
+- Default values should also be validated against type and constraints
+
+## Data File Validation
+
+### Required Data Validation
+- All data entries defined in `Data` map must be provided (unless optional flag is added)
+- Each data entry must have a corresponding value in the inputs
+
+### Path Validation
+- Validate that data file paths exist (when running in execution context)
+- Paths should be validated against the `Path` field in `DataSpec`
+
+### Extension Validation
+- If `Extensions` is defined, validate that the file extension matches one of the allowed extensions
+- Extension matching should be case-insensitive
+- File extension should be extracted from the file path
+
+## Inputs.json Structure Validation
+
+### Overall Structure
+- Validate that inputs.json is valid JSON
+- Validate that it's a map/dictionary structure
+- Validate that tool names in the inputs file match expected tool names
+
+### Tool Input Validation
+- For each tool in the inputs file:
+  - Validate that `Parameters` map matches the tool's `ParameterSpec` definitions
+  - Validate that `Datasets` map matches the tool's `DataSpec` definitions
+  - Run all parameter validations described above
+  - Run all data validations described above
+
+### Cross-Validation
+- Ensure no extra parameters are provided that aren't defined in the spec
+- Ensure no extra data entries are provided that aren't defined in the spec
+- Validate that all required parameters are present
+- Validate that all required data entries are present
+
+## Proposed Function Signatures
+
+```go
+// Validate a single parameter value against its spec
+func ValidateParameter(spec ParameterSpec, value interface{}) error
+
+// Validate all parameters against a tool spec
+func ValidateParameters(spec ToolSpec, inputs map[string]interface{}) error
+
+// Validate all data entries against a tool spec
+func ValidateData(spec ToolSpec, data map[string]string) error
+
+// Validate a complete ToolInput against a ToolSpec
+func ValidateInputs(spec ToolSpec, inputs ToolInput) error
+
+// Validate an InputFile against a SpecFile
+func ValidateInputFile(specFile SpecFile, inputFile InputFile) error
+```
+
+## Error Handling
+
+Validation functions should return descriptive errors that indicate:
+- Which parameter/data entry failed validation
+- What type of validation failed (type, range, required, etc.)
+- What the expected value/constraint was
+- What the actual value was (if safe to include)
+
+Consider using structured errors or error wrapping to allow callers to programmatically handle different validation failures.
+

--- a/pkg/toolspec/inputs.go
+++ b/pkg/toolspec/inputs.go
@@ -1,0 +1,33 @@
+package toolspec
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type ToolInput struct {
+	Parameters map[string]interface{} `json:"parameters"`
+	Datasets   map[string]string      `json:"data"`
+}
+
+type InputFile map[string]ToolInput
+
+func LoadInputs(rawData []byte) (InputFile, error) {
+	var inputFile InputFile
+	err := json.Unmarshal(rawData, &inputFile)
+	if err != nil {
+		return nil, err
+	}
+
+	return inputFile, nil
+}
+
+func (f InputFile) GetToolInput(toolName string) (ToolInput, error) {
+	toolInput, ok := f[toolName]
+	if !ok {
+		return ToolInput{}, fmt.Errorf("tool input %s was not found in the inputs file", toolName)
+	}
+
+	return toolInput, nil
+}
+

--- a/pkg/toolspec/parse.go
+++ b/pkg/toolspec/parse.go
@@ -1,0 +1,27 @@
+package toolspec
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+func (s *SpecFile) GetTool(toolName string) (ToolSpec, error) {
+	toolSpec, ok := s.Tools[toolName]
+	if !ok {
+		return ToolSpec{}, fmt.Errorf("tool %s was not found in the given specification file", toolName)
+	}
+
+	return toolSpec, nil
+}
+
+func LoadToolSpec(rawData []byte) (SpecFile, error) {
+	var toolSpec SpecFile
+	err := yaml.Unmarshal(rawData, &toolSpec)
+	if err != nil {
+		return SpecFile{}, err
+	}
+
+	return toolSpec, nil
+}
+

--- a/pkg/toolspec/spec.go
+++ b/pkg/toolspec/spec.go
@@ -1,0 +1,64 @@
+package toolspec
+
+import (
+	"github.com/alexander-lindner/go-cff"
+	"gopkg.in/yaml.v3"
+)
+
+type SpecFile struct {
+	Tools map[string]ToolSpec `yaml:"tools"`
+}
+
+type ToolSpec struct {
+	ID          string                   `json:"id" yaml:"-"`
+	Name        string                   `json:"name" yaml:"-"`
+	Title       string                   `json:"title" yaml:"title"`
+	Description string                   `json:"description" yaml:"description"`
+	Parameters  map[string]ParameterSpec `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+	Data        map[string]DataSpec      `json:"data,omitempty" yaml:"data,omitempty"`
+	Citation    cff.Cff                  `json:"citation,omitempty" yaml:"-"`
+}
+
+type ParameterSpec struct {
+	Name        string      `json:"name" yaml:"name"`
+	Description string      `json:"description,omitempty" yaml:"description,omitempty"`
+	ToolType    string      `json:"type" yaml:"type"`
+	IsArray     bool        `json:"array,omitempty" yaml:"array,omitempty" default:"false"`
+	Default     interface{} `json:"default,omitempty" yaml:"default,omitempty"`
+	Values      []string    `json:"values,omitempty" yaml:"values,omitempty"`
+	Min         float64     `json:"min,omitempty" yaml:"min,omitempty"`
+	Max         float64     `json:"max,omitempty" yaml:"max,omitempty"`
+	Optional    bool        `json:"optional,omitempty" yaml:"optional,omitempty"`
+}
+
+type DataSpec struct {
+	Path        string      `json:"path" yaml:"path"`
+	Description string      `json:"description,omitempty" yaml:"description,omitempty"`
+	Example     string      `json:"example,omitempty" yaml:"example,omitempty"`
+	Extension   interface{} `json:"-" yaml:"extension,omitempty"`
+	Extensions  []string    `json:"extension,omitempty"`
+}
+
+func (d *DataSpec) UnmarshalYAML(value *yaml.Node) error {
+	type dataSpecAlias DataSpec
+	var alias dataSpecAlias
+	if err := value.Decode(&alias); err != nil {
+		return err
+	}
+
+	*d = DataSpec(alias)
+
+	switch ext := d.Extension.(type) {
+	case string:
+		d.Extensions = []string{ext}
+	case []interface{}:
+		d.Extensions = make([]string, len(ext))
+		for i, e := range ext {
+			d.Extensions[i] = e.(string)
+		}
+	}
+
+	d.Extension = nil
+	return nil
+}
+


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Extracts tool specification logic into `pkg/toolspec` and updates API, cache, and image tooling to use the new shared types; adds validation design doc.
> 
> - **Core refactor**:
>   - Extract `toolSpec` into new shared package `pkg/toolspec` with `spec.go`, `parse.go`, `inputs.go`.
>   - Replace all usages of `internal/toolSpec` with `pkg/toolspec` across API, cache, tool runtime, and image handling.
> - **API/Runtime changes**:
>   - Update response/request types to use `toolspec.ToolSpec` and input structures.
>   - `internal/tool/create`: generate `inputs.json` via `toolspec.InputFile`/`ToolInput`.
>   - `internal/toolImage`: update spec load/read functions to return `toolspec.SpecFile/ToolSpec`; ensure citation handling preserved.
>   - `internal/cache`: cache now stores `toolspec.SpecFile` and `toolspec.ToolSpec` with corresponding getters/setters.
> - **Docs**:
>   - Add `pkg/toolspec/VALIDATION.md` outlining planned validation rules and function signatures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3401313eedab13520a7c7ee5e3b2113c75e4bf5c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->