### PR TITLE
Refresh gotap output UX and previews

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -64,6 +64,7 @@ func CreateServer() (*http.ServeMux, error) {
 	mux.HandleFunc("DELETE /runs/{id}", HandleApiKey(RunMiddleware(DeleteRun)))
 	mux.HandleFunc("POST /runs/{id}/start", HandleApiKey(RunMiddleware(HandleRunStart)))
 	mux.HandleFunc("GET /runs/{id}/results", HandleApiKey(RunMiddleware(ListRunResults)))
+	mux.HandleFunc("GET /runs/{id}/results/{filename}/preview", HandleApiKey(RunMiddleware(PreviewResultFile)))
 	mux.HandleFunc("GET /runs/{id}/results/{filename}", HandleApiKey(RunMiddleware(GetResultFile)))
 	mux.HandleFunc("POST /files", HandleApiKey(HandleFileUpload))
 	mux.HandleFunc("GET /files", HandleApiKey(FindFile))

--- a/api/results.go
+++ b/api/results.go
@@ -1,8 +1,11 @@
 package api
 
 import (
+	"bytes"
 	"fmt"
 	"net/http"
+	"net/url"
+	"strings"
 
 	"github.com/hydrocode-de/gorun/internal/files"
 	"github.com/hydrocode-de/gorun/internal/tool"
@@ -11,6 +14,27 @@ import (
 type ListRunResultsResponse struct {
 	Count int                `json:"count"`
 	Files []files.ResultFile `json:"files"`
+}
+
+type PreviewResultResponse struct {
+	Filename  string `json:"filename"`
+	MimeType  string `json:"mimeType"`
+	Encoding  string `json:"encoding"`
+	Truncated bool   `json:"truncated"`
+	Content   string `json:"content"`
+}
+
+func resultPathFromRequest(r *http.Request) (string, error) {
+	filename := r.PathValue("filename")
+	if filename == "" {
+		return "", fmt.Errorf("missing filename")
+	}
+
+	decoded, err := url.PathUnescape(filename)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimPrefix(decoded, "/"), nil
 }
 
 func ListRunResults(w http.ResponseWriter, r *http.Request, tool tool.Tool) {
@@ -26,14 +50,46 @@ func ListRunResults(w http.ResponseWriter, r *http.Request, tool tool.Tool) {
 }
 
 func GetResultFile(w http.ResponseWriter, r *http.Request, tool tool.Tool) {
-	//filename := r.URL.Query().Get("filename")
-	filename := r.PathValue("filename")
+	filename, err := resultPathFromRequest(r)
+	if err != nil {
+		RespondWithError(w, http.StatusBadRequest, err.Error())
+		return
+	}
 
-	info, err := tool.WriteResultFile(filename, w)
+	var payload bytes.Buffer
+	info, err := tool.WriteResultFile(filename, &payload)
 	if err != nil {
 		RespondWithError(w, http.StatusInternalServerError, err.Error())
+		return
 	}
 
 	w.Header().Set("Content-Type", info.MimeType)
 	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s", info.Filename))
+	_, _ = w.Write(payload.Bytes())
+}
+
+func PreviewResultFile(w http.ResponseWriter, r *http.Request, tool tool.Tool) {
+	filename, err := resultPathFromRequest(r)
+	if err != nil {
+		RespondWithError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	preview, err := tool.PreviewResultFile(filename)
+	if err != nil {
+		if strings.Contains(err.Error(), "preview is not available") {
+			RespondWithError(w, http.StatusUnsupportedMediaType, err.Error())
+			return
+		}
+		RespondWithError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	RespondWithJSON(w, http.StatusOK, PreviewResultResponse{
+		Filename:  preview.Filename,
+		MimeType:  preview.MimeType,
+		Encoding:  preview.Encoding,
+		Truncated: preview.Truncated,
+		Content:   preview.Content,
+	})
 }

--- a/api/runs_state.go
+++ b/api/runs_state.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/hydrocode-de/gorun/internal/db"
@@ -15,14 +16,78 @@ import (
 )
 
 type RunsResponse struct {
-	Count  int         `json:"count"`
-	Status string      `json:"status"`
-	Runs   []tool.Tool `json:"runs"`
+	Count  int           `json:"count"`
+	Status string        `json:"status"`
+	Runs   []RunListItem `json:"runs"`
 }
 
 type RunDetailResponse struct {
 	tool.Tool
 	GotapMetadata interface{} `json:"gotap_metadata,omitempty"`
+}
+
+type RunResultSummary struct {
+	ArtifactCount int   `json:"artifact_count"`
+	LogCount      int   `json:"log_count"`
+	InternalCount int   `json:"internal_count"`
+	MetadataCount int   `json:"metadata_count"`
+	TotalSize     int64 `json:"total_size"`
+}
+
+type RunListItem struct {
+	tool.Tool
+	GotapMetadata interface{}       `json:"gotap_metadata,omitempty"`
+	ResultSummary *RunResultSummary `json:"result_summary,omitempty"`
+}
+
+func classifyResultFile(name string) string {
+	switch name {
+	case "_metadata.json":
+		return "metadata"
+	case "STDOUT.log", "STDERR.log":
+		return "log"
+	}
+	if strings.HasPrefix(name, ".") || strings.HasPrefix(name, "_") {
+		return "internal"
+	}
+	return "artifact"
+}
+
+func summarizeResults(run tool.Tool) *RunResultSummary {
+	results, err := run.ListResults()
+	if err != nil {
+		return nil
+	}
+
+	summary := &RunResultSummary{}
+	for _, result := range results {
+		switch classifyResultFile(result.Name) {
+		case "artifact":
+			summary.ArtifactCount++
+		case "log":
+			summary.LogCount++
+		case "metadata":
+			summary.MetadataCount++
+		case "internal":
+			summary.InternalCount++
+		}
+		summary.TotalSize += result.Size
+	}
+
+	return summary
+}
+
+func appendMetadataFields(run db.Run, item *RunListItem) {
+	if !run.GotapMetadata.Valid {
+		return
+	}
+
+	var metadata interface{}
+	if err := json.Unmarshal([]byte(run.GotapMetadata.String), &metadata); err != nil {
+		log.Printf("failed parsing gotap metadata for run %d: %v", run.ID, err)
+		return
+	}
+	item.GotapMetadata = metadata
 }
 
 func GetAllRuns(w http.ResponseWriter, r *http.Request) {
@@ -65,14 +130,17 @@ func GetAllRuns(w http.ResponseWriter, r *http.Request) {
 		RespondWithError(w, http.StatusInternalServerError, err.Error())
 	}
 
-	var toolRuns []tool.Tool
-	for _, run := range runs {
-		toolRun, err := tool.FromDBRun(run)
+	var toolRuns []RunListItem
+	for _, dbRun := range runs {
+		toolRun, err := tool.FromDBRun(dbRun)
 		if err != nil {
 			log.Printf("Error while loading tool run: %s", err)
 			continue
 		}
-		toolRuns = append(toolRuns, toolRun)
+		item := RunListItem{Tool: toolRun}
+		appendMetadataFields(dbRun, &item)
+		item.ResultSummary = summarizeResults(toolRun)
+		toolRuns = append(toolRuns, item)
 	}
 
 	RespondWithJSON(w, http.StatusOK, RunsResponse{

--- a/cli/serve.go
+++ b/cli/serve.go
@@ -76,7 +76,7 @@ func startBackgroundTasksAndWait(ctx context.Context) {
 	}
 
 	// Wait for cache to be marked as initialized
-	for !cacheInstance.Initialised {
+	for !cacheInstance.IsInitialised() {
 		log.Println("Waiting for cache initialization to complete...")
 		time.Sleep(time.Second)
 	}

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -1,25 +1,37 @@
 package cache
 
 import (
+	"sync"
+
 	toolspec "github.com/hydrocode-de/tool-spec-go"
 )
 
 type Cache struct {
+	mu          sync.RWMutex
 	images      map[string]toolspec.SpecFile
 	tools       map[string]toolspec.ToolSpec
 	Initialised bool
 }
 
 func (c *Cache) GetToolSpec(key string) (*toolspec.ToolSpec, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	spec, ok := c.tools[key]
 	return &spec, ok
 }
 
 func (c *Cache) SetToolSpec(key string, spec *toolspec.ToolSpec) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	c.tools[key] = *spec
 }
 
 func (c *Cache) ListToolSpecs() []toolspec.ToolSpec {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	specs := make([]toolspec.ToolSpec, 0)
 	for _, spec := range c.tools {
 		specs = append(specs, spec)
@@ -28,16 +40,39 @@ func (c *Cache) ListToolSpecs() []toolspec.ToolSpec {
 }
 
 func (c *Cache) GetImageSpec(key string) (*toolspec.SpecFile, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	spec, ok := c.images[key]
 	return &spec, ok
 }
 
 func (c *Cache) SetImageSpec(key string, spec toolspec.SpecFile) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	c.images[key] = spec
 }
 
 func (c *Cache) Reset() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	c.tools = make(map[string]toolspec.ToolSpec)
 	c.images = make(map[string]toolspec.SpecFile)
 	c.Initialised = false
+}
+
+func (c *Cache) IsInitialised() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return c.Initialised
+}
+
+func (c *Cache) SetInitialised(initialised bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.Initialised = initialised
 }

--- a/internal/files/find.go
+++ b/internal/files/find.go
@@ -37,10 +37,11 @@ func ReadDir(dirname string, recursive bool, toolBasePath string) ([]ResultFile,
 			abs := path.Join(dirname, file.Name())
 			rel, _ := filepath.Rel(toolBasePath, abs)
 			result = append(result, ResultFile{
-				Name:    filepath.Base(file.Name()),
-				RelPath: rel,
-				AbsPath: abs,
-				Size:    info.Size(),
+				Name:         filepath.Base(file.Name()),
+				RelPath:      rel,
+				AbsPath:      abs,
+				Size:         info.Size(),
+				LastModified: info.ModTime(),
 			})
 		}
 	}

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -5,8 +5,8 @@ import (
 	"io/fs"
 )
 
-//go:embed manager/**/*
-//go:embed manager/*
+//go:embed all:manager/**/*
+//go:embed all:manager/*
 var manager embed.FS
 
 func GetManager() fs.FS {

--- a/internal/tool/files.go
+++ b/internal/tool/files.go
@@ -7,14 +7,17 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"path/filepath"
+	"slices"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/hydrocode-de/gorun/internal/files"
 )
 
 func (t *Tool) ListResults() ([]files.ResultFile, error) {
-	if t.Status != "finished" {
-		return nil, errors.New("unfished tools cannot list results")
+	if t.Status != "finished" && t.Status != "errored" {
+		return nil, errors.New("unfinished tools cannot list results")
 	}
 
 	hostOut, ok := t.Mounts["/out"]
@@ -24,6 +27,28 @@ func (t *Tool) ListResults() ([]files.ResultFile, error) {
 	return files.ReadDir(hostOut, true, hostOut)
 }
 
+func (t *Tool) resolveResultFile(resultPath string) (*files.ResultFile, error) {
+	results, err := t.ListResults()
+	if err != nil {
+		return nil, err
+	}
+
+	normalized := filepath.ToSlash(path.Clean(strings.TrimSpace(resultPath)))
+	normalized = strings.TrimPrefix(normalized, "./")
+	if normalized == "." || normalized == "" {
+		return nil, fmt.Errorf("the result file %s was not found in the tool %s results", resultPath, t.Name)
+	}
+
+	for _, file := range results {
+		if filepath.ToSlash(file.RelPath) == normalized {
+			matchedFile := file
+			return &matchedFile, nil
+		}
+	}
+
+	return nil, fmt.Errorf("the result file %s was not found in the tool %s results", resultPath, t.Name)
+}
+
 type WriteFileMeta struct {
 	Filename string
 	MimeType string
@@ -31,24 +56,12 @@ type WriteFileMeta struct {
 }
 
 func (t *Tool) WriteResultFile(resultPath string, w io.Writer) (*WriteFileMeta, error) {
-	files, err := t.ListResults()
+	result, err := t.resolveResultFile(resultPath)
 	if err != nil {
 		return nil, err
 	}
 
-	var matchedFile string
-	for _, file := range files {
-		if strings.HasSuffix(resultPath, file.Name) {
-			matchedFile = file.RelPath
-			break
-		}
-	}
-	if matchedFile == "" {
-		return nil, fmt.Errorf("the result file %s was not found in the tool %s results", resultPath, t.Name)
-	}
-
-	fullPath := path.Join(t.Mounts["/out"], matchedFile)
-	file, err := os.Open(fullPath)
+	file, err := os.Open(result.AbsPath)
 	if err != nil {
 		return nil, err
 	}
@@ -71,8 +84,63 @@ func (t *Tool) WriteResultFile(resultPath string, w io.Writer) (*WriteFileMeta, 
 	}
 
 	return &WriteFileMeta{
-		Filename: path.Base(matchedFile),
+		Filename: path.Base(result.RelPath),
 		MimeType: mimeType,
-		FullPath: fullPath,
+		FullPath: result.AbsPath,
+	}, nil
+}
+
+type PreviewResultFileMeta struct {
+	Filename  string `json:"filename"`
+	MimeType  string `json:"mimeType"`
+	Encoding  string `json:"encoding"`
+	Truncated bool   `json:"truncated"`
+	Content   string `json:"content"`
+}
+
+var previewableExtensions = []string{".json", ".txt", ".log", ".md", ".csv"}
+
+const previewByteLimit = 64 * 1024
+
+func (t *Tool) PreviewResultFile(resultPath string) (*PreviewResultFileMeta, error) {
+	result, err := t.resolveResultFile(resultPath)
+	if err != nil {
+		return nil, err
+	}
+
+	file, err := os.Open(result.AbsPath)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	buffer := make([]byte, previewByteLimit+1)
+	readBytes, err := file.Read(buffer)
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+
+	contentBytes := buffer[:readBytes]
+	truncated := false
+	if len(contentBytes) > previewByteLimit {
+		contentBytes = contentBytes[:previewByteLimit]
+		truncated = true
+	}
+
+	mimeType := http.DetectContentType(contentBytes)
+	extension := strings.ToLower(path.Ext(result.RelPath))
+	if !strings.HasPrefix(mimeType, "text/") && mimeType != "application/json" && !slices.Contains(previewableExtensions, extension) {
+		return nil, fmt.Errorf("preview is not available for binary or unsupported file type: %s", result.RelPath)
+	}
+	if !utf8.Valid(contentBytes) {
+		return nil, fmt.Errorf("preview is not available for binary or unsupported file type: %s", result.RelPath)
+	}
+
+	return &PreviewResultFileMeta{
+		Filename:  result.RelPath,
+		MimeType:  mimeType,
+		Encoding:  "utf-8",
+		Truncated: truncated,
+		Content:   string(contentBytes),
 	}, nil
 }

--- a/internal/tool/run.go
+++ b/internal/tool/run.go
@@ -95,7 +95,7 @@ func RunTool(ctx context.Context, opt RunToolOptions) error {
 		}
 		if gotapFound {
 			config.Entrypoint = []string{gotapPath}
-			config.Cmd = []string{"run", tool.Name, "--input-file", "/in/inputs.json", "--spec-file", "/src/tool.yml", "--output-folder", "/out"}
+			config.Cmd = []string{"run", tool.Name, "--input-file", "/in/inputs.json", "--spec-file", "/src/tool.yml"}
 			runMode = "gotap"
 			fmt.Printf("detected gotap shim at %s\n", gotapPath)
 		}

--- a/internal/toolImage/image.go
+++ b/internal/toolImage/image.go
@@ -110,7 +110,7 @@ func ReadAllTools(ctx context.Context, cache *cache.Cache, verbose bool) ([]stri
 		}
 	}
 
-	cache.Initialised = true
+	cache.SetInitialised(true)
 	return allTools, nil
 }
 

--- a/manager/src/lib/auth.svelte.ts
+++ b/manager/src/lib/auth.svelte.ts
@@ -75,13 +75,11 @@ export async function initializeAuth() {
 
 export async function authorizedFetch(url: string, options?: RequestInit): Promise<Response> {
     await refreshToken()
-    if (!config.auth.access_token) {
-        return Promise.reject("Cannot create a new access token.");
-    }
 
     const headers = new Headers(options?.headers);
-    headers.set("Authorization", `Bearer ${config.auth.access_token}`);
+    if (config.auth.access_token) {
+        headers.set("Authorization", `Bearer ${config.auth.access_token}`);
+    }
 
     return fetch(url, { ...options, headers });
 }
-

--- a/manager/src/lib/components/DataInput.svelte
+++ b/manager/src/lib/components/DataInput.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { authorizedFetch } from "$lib/auth.svelte";
     import { config } from "$lib/state.svelte";
     import type { ResultFile } from "$lib/types/ResultFile";
     import type { RemoteFile, TempFile } from "$lib/types/TempFile";
@@ -53,11 +54,8 @@
         //  POST the file to the server using multipart formdata
         const formData = new FormData()
         formData.append('file', file)
-        fetch(`${config.apiServer}/files`, {
+        authorizedFetch(`${config.apiServer}/files`, {
             method: 'POST',
-            headers: {
-                'X-User-ID': config.auth.user.id
-            },
             body: formData
         })
         .then(res => res.json())

--- a/manager/src/lib/components/FileAutocomplete.svelte
+++ b/manager/src/lib/components/FileAutocomplete.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { authorizedFetch } from "$lib/auth.svelte";
     import { bytesToSize } from "$lib/helper";
 import { config } from "$lib/state.svelte";
     import type { ResultFile } from "$lib/types/ResultFile";
@@ -26,11 +27,7 @@ import { config } from "$lib/state.svelte";
     async function query() {
         if (pattern.length !== 0 && !loading) {
             loading = true;
-            const res = await fetch(`${config.apiServer}/files?pattern=${q}&target=both`, {
-                headers: {
-                    'X-User-ID': config.auth.user.id
-                }
-            });
+            const res = await authorizedFetch(`${config.apiServer}/files?pattern=${q}&target=both`);
             const data = await res.json();
 
             // sort by last modified

--- a/manager/src/lib/components/ParameterInput.svelte
+++ b/manager/src/lib/components/ParameterInput.svelte
@@ -14,6 +14,18 @@
 //    let value: string | number | boolean | Date | null | {[key: string]: any} | any[] = $state(parameter.default ? parameter.default : null);
     let showDescription = $state(false);
 
+    function getNumericValue(input: HTMLInputElement): number | null {
+        if (input.value === '') {
+            return null;
+        }
+
+        if (parameter.type === 'integer') {
+            return Number.parseInt(input.value, 10);
+        }
+
+        return Number.parseFloat(input.value);
+    }
+
 </script>
 
 <style>
@@ -64,7 +76,7 @@
                 <input 
                     type="number" 
                     bind:value 
-                    oninput={e => oninput((e.target as HTMLInputElement)!.value)}
+                    oninput={e => oninput(getNumericValue((e.target as HTMLInputElement)!))}
                     class="w-full px-3 py-1.5 border border-gray-200 rounded-md shadow-sm focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500"
                 >
             {:else if parameter.type === 'boolean'}

--- a/manager/src/lib/helper.ts
+++ b/manager/src/lib/helper.ts
@@ -16,3 +16,32 @@ export const bytesToSize = (bytes: number): string => {
 
     return `${short.toFixed(1)} ${suffix}`
 }
+
+export const formatPercentFromPermille = (permille: number): string => {
+    return `${(permille / 10).toFixed(1)}%`;
+}
+
+export const titleCase = (value: string): string => {
+    return value
+        .toLowerCase()
+        .split(' ')
+        .filter(Boolean)
+        .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+        .join(' ');
+}
+
+export const formatDurationFromNanoseconds = (nanoseconds: number): string => {
+    if (nanoseconds < 1_000) {
+        return `${nanoseconds} ns`;
+    }
+
+    if (nanoseconds < 1_000_000) {
+        return `${(nanoseconds / 1_000).toFixed(1)} us`;
+    }
+
+    if (nanoseconds < 1_000_000_000) {
+        return `${(nanoseconds / 1_000_000).toFixed(1)} ms`;
+    }
+
+    return `${(nanoseconds / 1_000_000_000).toFixed(2)} s`;
+}

--- a/manager/src/lib/results.ts
+++ b/manager/src/lib/results.ts
@@ -1,0 +1,74 @@
+import type { ClassifiedResultFile, ResultFile, ResultFileKind } from "./types/ResultFile";
+
+const previewableExtensions = new Set(['.json', '.txt', '.log', '.md', '.csv']);
+const kindOrder: Record<ResultFileKind, number> = {
+    artifact: 0,
+    log: 1,
+    metadata: 2,
+    internal: 3
+};
+
+export interface PreviewResponse {
+    filename: string;
+    mimeType: string;
+    encoding: string;
+    truncated: boolean;
+    content: string;
+}
+
+export function classifyResultFile(file: ResultFile): ClassifiedResultFile {
+    let kind: ResultFileKind = 'artifact';
+    if (file.name === '_metadata.json') {
+        kind = 'metadata';
+    } else if (file.name === 'STDOUT.log' || file.name === 'STDERR.log') {
+        kind = 'log';
+    } else if (file.name.startsWith('.') || file.name.startsWith('_')) {
+        kind = 'internal';
+    }
+
+    const extension = file.name.includes('.') ? `.${file.name.split('.').pop()!.toLowerCase()}` : '';
+    const previewable = previewableExtensions.has(extension) || kind === 'log';
+    const relParts = file.relPath.split('/').filter(Boolean);
+    const groupPath = relParts.length > 1 ? relParts.slice(0, -1).join('/') : '.';
+
+    return {
+        ...file,
+        kind,
+        previewable,
+        displayName: file.name,
+        groupPath
+    };
+}
+
+export function sortResultFiles(files: ResultFile[]): ClassifiedResultFile[] {
+    return files
+        .map(classifyResultFile)
+        .sort((left, right) => {
+            const kindCmp = kindOrder[left.kind] - kindOrder[right.kind];
+            if (kindCmp !== 0) {
+                return kindCmp;
+            }
+            const groupCmp = left.groupPath.localeCompare(right.groupPath);
+            if (groupCmp !== 0) {
+                return groupCmp;
+            }
+            return left.displayName.localeCompare(right.displayName);
+        });
+}
+
+export function groupResultFiles(files: ClassifiedResultFile[]): Array<{ path: string; files: ClassifiedResultFile[] }> {
+    const groups = new Map<string, ClassifiedResultFile[]>();
+    for (const file of files) {
+        const bucket = groups.get(file.groupPath) ?? [];
+        bucket.push(file);
+        groups.set(file.groupPath, bucket);
+    }
+
+    return Array.from(groups.entries())
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([path, groupedFiles]) => ({ path, files: groupedFiles }));
+}
+
+export function resultPathParam(relPath: string): string {
+    return encodeURIComponent(relPath);
+}

--- a/manager/src/lib/types/ResultFile.ts
+++ b/manager/src/lib/types/ResultFile.ts
@@ -1,7 +1,16 @@
+export type ResultFileKind = 'artifact' | 'log' | 'metadata' | 'internal';
+
 export interface ResultFile {
     name: string;
     relPath: string;
     absPath: string;
     size: number;
     lastModified?: Date;
+}
+
+export interface ClassifiedResultFile extends ResultFile {
+    kind: ResultFileKind;
+    previewable: boolean;
+    displayName: string;
+    groupPath: string;
 }

--- a/manager/src/lib/types/RunState.ts
+++ b/manager/src/lib/types/RunState.ts
@@ -1,9 +1,17 @@
+export interface RunResultSummary {
+    artifact_count: number;
+    log_count: number;
+    internal_count: number;
+    metadata_count: number;
+    total_size: number;
+}
+
 export interface RunState {
     id: number;
     name: string,
     title: string,
     description: string,
-    dockerImage: string,
+    image: string,
     mounts?: {
         [containerPath: string]: string
     },
@@ -19,5 +27,6 @@ export interface RunState {
     finished_at?: Date,
     has_errored: boolean,
     error_message?: string,
-    gotap_metadata?: Record<string, unknown>
+    gotap_metadata?: Record<string, unknown>,
+    result_summary?: RunResultSummary
 }

--- a/manager/src/routes/runs/+layout.ts
+++ b/manager/src/routes/runs/+layout.ts
@@ -1,5 +1,5 @@
-import { goto } from "$app/navigation";
-import { refreshToken } from "$lib/auth.svelte";
+import { redirect } from "@sveltejs/kit";
+import { authorizedFetch } from "$lib/auth.svelte";
 import { config } from "$lib/state.svelte";
 import type { RunState } from "$lib/types/RunState";
 import type { LayoutLoad } from "./$types";
@@ -14,19 +14,15 @@ export const load: LayoutLoad = async ({ url, fetch }): Promise<{runs: RunState[
         backendUrl += `?status=${status}`
     }
     console.log(backendUrl);
-    await refreshToken();
-    if (!config.auth.access_token) {
-        goto('/manager/login');
-    }
-
-    const headers = new Headers();
-    headers.set("Authorization", `Bearer ${config.auth.access_token}`);
-    headers.set("Content-Type", "application/json");
-
-    const res = await fetch(backendUrl, {
+    const res = await authorizedFetch(backendUrl, {
         method: 'GET',
-        headers: headers
+        headers: {
+            "Content-Type": "application/json"
+        }
     })
+    if (res.status === 401) {
+        throw redirect(307, '/manager/login');
+    }
     const data = await res.json()
     const runs = data.runs as RunState[]
 

--- a/manager/src/routes/runs/+page.svelte
+++ b/manager/src/routes/runs/+page.svelte
@@ -2,8 +2,10 @@
     import moment from 'moment';
     import type { RunState } from "$lib/types/RunState";
     import { page } from '$app/state';
-    import { goto, invalidate, invalidateAll, replaceState } from '$app/navigation';
+    import { goto, invalidateAll } from '$app/navigation';
     import { config } from '$lib/state.svelte.js';
+    import { authorizedFetch } from '$lib/auth.svelte';
+    import { bytesToSize } from '$lib/helper';
 
     let {data} = $props();
 
@@ -35,11 +37,8 @@
 
     async function onStart(runId: number) {
         const runUrl = `${config.apiServer}/runs/${runId}/start`;
-        const res = await fetch(runUrl, { 
-            method: 'POST',
-            headers: {
-                'X-User-ID': config.auth.user.id
-            }
+        const res = await authorizedFetch(runUrl, { 
+            method: 'POST'
         });
         const data = await res.json();
         $inspect(data);
@@ -48,11 +47,8 @@
 
     async function onDelete(runId: number) {
         const runUrl = `${config.apiServer}/runs/${runId}`;
-        const res = await fetch(runUrl, { 
-            method: 'DELETE',
-            headers: {
-                'X-User-ID': config.auth.user.id
-            }
+        const res = await authorizedFetch(runUrl, { 
+            method: 'DELETE'
         });
         const data = await res.json();
         console.log(data.message);
@@ -91,6 +87,9 @@
                     Finished
                 </th>
                 <th scope="col" class="px-6 py-3 font-semibold">
+                    Outputs
+                </th>
+                <th scope="col" class="px-6 py-3 font-semibold">
                     Actions
                 </th>
             </tr>
@@ -111,6 +110,32 @@
                         {run.status === 'finished' ? moment(run.finished_at).fromNow() : null}
                         {run.status === 'errored' ? 'Errored' : null}
                     </td>
+                    <td class="px-6 py-4">
+                        {#if run.result_summary}
+                            <div class="flex flex-wrap gap-2">
+                                <span class="rounded-full bg-slate-100 px-2 py-1 text-xs font-medium text-slate-700">
+                                    {run.result_summary.artifact_count} artifacts
+                                </span>
+                                {#if run.result_summary.log_count > 0}
+                                    <span class="rounded-full bg-amber-100 px-2 py-1 text-xs font-medium text-amber-700">
+                                        {run.result_summary.log_count} logs
+                                    </span>
+                                {/if}
+                                {#if run.gotap_metadata}
+                                    <span class="rounded-full bg-blue-100 px-2 py-1 text-xs font-medium text-blue-700">
+                                        gotap
+                                    </span>
+                                {/if}
+                                {#if run.result_summary.total_size > 0}
+                                    <span class="rounded-full bg-emerald-100 px-2 py-1 text-xs font-medium text-emerald-700">
+                                        {bytesToSize(run.result_summary.total_size)}
+                                    </span>
+                                {/if}
+                            </div>
+                        {:else}
+                            <span class="text-xs text-gray-500">No output summary</span>
+                        {/if}
+                    </td>
                     <td class="px-6 py-4 flex gap-2">
                         {#if run.status === 'running'}
                             Running...
@@ -129,16 +154,24 @@
                         </button>
                         {/if}
                         {#if run.status === 'finished'}
-                        <button
-                            disabled
-                            class="text-gray-200 hover:cursor-not-allowed" 
-                            title="Download" 
-                            aria-label="Download Result"
-                        >
-                            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-                            </svg>
-                        </button>
+                            <a
+                                href={`/manager/runs/${run.id}?tab=outputs`}
+                                class="text-blue-600 hover:text-blue-800"
+                                title="Open results"
+                                aria-label="Open Result"
+                            >
+                                Open results
+                            </a>
+                        {/if}
+                        {#if run.status === 'errored' && (run.result_summary?.log_count ?? 0) > 0}
+                            <a
+                                href={`/manager/runs/${run.id}?tab=logs`}
+                                class="text-amber-700 hover:text-amber-900"
+                                title="View error logs"
+                                aria-label="View error logs"
+                            >
+                                View error
+                            </a>
                         {/if}
                         {#if run.status !== 'running'}
                         <button 

--- a/manager/src/routes/runs/+page.svelte
+++ b/manager/src/routes/runs/+page.svelte
@@ -15,9 +15,39 @@
     });
     $inspect(runs);
 
+    let autoRefresh = $state(true);
+    let refreshing = $state(false);
+
     // refresh 
     async function refresh() {
-        invalidateAll();
+        if (refreshing) {
+            return;
+        }
+        refreshing = true;
+        try {
+            await invalidateAll();
+        } finally {
+            refreshing = false;
+        }
+    }
+
+    function onRefreshToggleClick(event: MouseEvent) {
+        const target = event.target as HTMLElement | null;
+        if (target?.closest('input')) {
+            return;
+        }
+        void refresh();
+    }
+
+    function onRefreshToggleKeydown(event: KeyboardEvent) {
+        const target = event.target as HTMLElement | null;
+        if (target?.closest('input')) {
+            return;
+        }
+        if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            void refresh();
+        }
     }
 
     // Define available status options
@@ -55,11 +85,40 @@
 
         await refresh();
     }
+
+    $effect(() => {
+        if (!autoRefresh) {
+            return;
+        }
+
+        const intervalId = window.setInterval(() => {
+            void refresh();
+        }, 5000);
+
+        return () => {
+            window.clearInterval(intervalId);
+        };
+    });
 </script>
 
-<button onclick={refresh} class="text-blue-600 hover:text-blue-800 hover:cursor-pointer" title="Refresh" aria-label="Refresh">
-    Refresh
-</button>
+<div
+    role="button"
+    tabindex="0"
+    class="mb-3 inline-flex items-center gap-3 rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-700 shadow-sm hover:bg-gray-50 hover:cursor-pointer"
+    title="Refresh runs"
+    aria-label="Refresh runs"
+    onclick={onRefreshToggleClick}
+    onkeydown={onRefreshToggleKeydown}
+>
+    <input
+        type="checkbox"
+        bind:checked={autoRefresh}
+        class="rounded border-gray-300"
+        aria-label="Enable automatic refresh"
+    />
+    <span class="font-medium text-gray-900">{refreshing ? 'Refreshing...' : 'Refresh every 5 seconds'}</span>
+    <span class="text-xs text-gray-500">click to refresh now</span>
+</div>
 <div class="relative overflow-x-auto shadow-md sm:rounded-lg">
     <table class="w-full text-sm text-left">
         <thead class="text-xs uppercase bg-gray-100">

--- a/manager/src/routes/runs/[runId]/+page.svelte
+++ b/manager/src/routes/runs/[runId]/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { page } from "$app/state";
     import moment from "moment";
     import type { PageProps } from "./$types";
     import { bytesToSize } from "$lib/helper";
@@ -7,6 +8,7 @@
     let { data }: PageProps = $props();
     let run = data.run;
     let files = data.files;
+    let initialTab = $derived((page.url.searchParams.get('tab') ?? 'overview') as 'overview' | 'outputs' | 'logs' | 'raw');
     $inspect(data);
 
 </script>
@@ -43,12 +45,16 @@
             <span>Finished {moment(run.finished_at).fromNow()}</span>
             <span>{files.length} results ({bytesToSize(files.map(f => f.size).reduce((a, b) => a + b, 0))})</span> 
         </div>
-        <FinishedRun {run} {files} />
+        <FinishedRun {run} {files} {initialTab} />
     {:else if run.status === 'errored'}
-        <div class="mt-2 text-sm text-gray-600">
-            Errored {moment(run.finished_at).fromNow()}
+        <div class="flex flex-row justify-between mt-2 text-sm text-gray-600">
+            <span>Errored {moment(run.finished_at).fromNow()}</span>
+            <span>{files.length} captured files ({bytesToSize(files.map(f => f.size).reduce((a, b) => a + b, 0))})</span>
         </div>
         <p class="mt-2 text-sm text-red-500">{run.error_message}</p>
+        <div class="mt-4">
+            <FinishedRun {run} {files} {initialTab} />
+        </div>
     {:else if run.status === 'pending'}
         <button 
             disabled

--- a/manager/src/routes/runs/[runId]/+page.svelte
+++ b/manager/src/routes/runs/[runId]/+page.svelte
@@ -10,7 +10,6 @@
     let files = data.files;
     let initialTab = $derived((page.url.searchParams.get('tab') ?? 'overview') as 'overview' | 'outputs' | 'logs' | 'raw');
     $inspect(data);
-
 </script>
 
 {#if run}

--- a/manager/src/routes/runs/[runId]/+page.ts
+++ b/manager/src/routes/runs/[runId]/+page.ts
@@ -2,33 +2,44 @@ import { config } from "$lib/state.svelte";
 import type { ResultFile } from "$lib/types/ResultFile";
 import type { RunState } from "$lib/types/RunState";
 import type { PageLoad } from "./$types";
+import { refreshToken } from "$lib/auth.svelte";
 
 export const load: PageLoad = async ({ params, parent, fetch }): Promise<{run: RunState | undefined, files: ResultFile[]}> => {
-    const parentData = await parent();
-    const run = parentData.runs.find(run => run.id === Number(params.runId));
+    await parent();
+    await refreshToken();
 
-    let files: ResultFile[];
-    if (run) {
-        const res = await fetch(`${config.apiServer}/runs/${run.id}/results`, {
-            headers: {
-                'X-User-ID': config.auth.user.id
-            }
-        }).then(resp => {
-            if (resp.ok) {
-                return resp.json();
-            } else {
-                throw new Error(`Failed to fetch results for run ${run.id}`);
-            }
-        }).catch(error => {
-            console.log(`Failed to fetch results for run ${run.id}`, error);
-            return {
-                files: []
-            }
+    const headers = new Headers();
+    headers.set("Authorization", `Bearer ${config.auth.access_token}`);
+    headers.set("Content-Type", "application/json");
+
+    const runId = Number(params.runId);
+    let run: RunState | undefined;
+    try {
+        const response = await fetch(`${config.apiServer}/runs/${runId}`, {
+            method: 'GET',
+            headers
         });
+        if (response.ok) {
+            run = await response.json() as RunState;
+        }
+    } catch (error) {
+        console.log(`Failed to fetch run ${runId}`, error);
+    }
 
-        files = res.files;
-    } else {
-        files = [];
+    let files: ResultFile[] = [];
+    if (run) {
+        try {
+            const response = await fetch(`${config.apiServer}/runs/${run.id}/results`, {
+                method: 'GET',
+                headers
+            });
+            if (response.ok) {
+                const payload = await response.json();
+                files = payload.files as ResultFile[];
+            }
+        } catch (error) {
+            console.log(`Failed to fetch results for run ${run.id}`, error);
+        }
     }
 
     return {

--- a/manager/src/routes/runs/[runId]/+page.ts
+++ b/manager/src/routes/runs/[runId]/+page.ts
@@ -1,24 +1,25 @@
 import { config } from "$lib/state.svelte";
 import type { ResultFile } from "$lib/types/ResultFile";
 import type { RunState } from "$lib/types/RunState";
+import { redirect } from "@sveltejs/kit";
 import type { PageLoad } from "./$types";
-import { refreshToken } from "$lib/auth.svelte";
+import { authorizedFetch } from "$lib/auth.svelte";
 
 export const load: PageLoad = async ({ params, parent, fetch }): Promise<{run: RunState | undefined, files: ResultFile[]}> => {
     await parent();
-    await refreshToken();
-
-    const headers = new Headers();
-    headers.set("Authorization", `Bearer ${config.auth.access_token}`);
-    headers.set("Content-Type", "application/json");
 
     const runId = Number(params.runId);
     let run: RunState | undefined;
     try {
-        const response = await fetch(`${config.apiServer}/runs/${runId}`, {
+        const response = await authorizedFetch(`${config.apiServer}/runs/${runId}`, {
             method: 'GET',
-            headers
+            headers: {
+                "Content-Type": "application/json"
+            }
         });
+        if (response.status === 401) {
+            throw redirect(307, '/manager/login');
+        }
         if (response.ok) {
             run = await response.json() as RunState;
         }
@@ -29,10 +30,15 @@ export const load: PageLoad = async ({ params, parent, fetch }): Promise<{run: R
     let files: ResultFile[] = [];
     if (run) {
         try {
-            const response = await fetch(`${config.apiServer}/runs/${run.id}/results`, {
+            const response = await authorizedFetch(`${config.apiServer}/runs/${run.id}/results`, {
                 method: 'GET',
-                headers
+                headers: {
+                    "Content-Type": "application/json"
+                }
             });
+            if (response.status === 401) {
+                throw redirect(307, '/manager/login');
+            }
             if (response.ok) {
                 const payload = await response.json();
                 files = payload.files as ResultFile[];

--- a/manager/src/routes/runs/[runId]/FinishedRun.svelte
+++ b/manager/src/routes/runs/[runId]/FinishedRun.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { bytesToSize } from "$lib/helper";
+    import { bytesToSize, formatDurationFromNanoseconds, formatPercentFromPermille, titleCase } from "$lib/helper";
     import { authorizedFetch } from "$lib/auth.svelte";
     import { config } from "$lib/state.svelte";
     import { groupResultFiles, resultPathParam, sortResultFiles, type PreviewResponse } from "$lib/results";
@@ -78,6 +78,44 @@
         if (Array.isArray(value)) return value.length === 0 ? '[]' : `${value.length} item${value.length === 1 ? '' : 's'}`;
         if (typeof value === 'object') return `${Object.keys(value as Record<string, unknown>).length} field${Object.keys(value as Record<string, unknown>).length === 1 ? '' : 's'}`;
         return String(value);
+    }
+
+    function formatMetadataLabel(key: string): string {
+        const normalizedKey = key.toUpperCase();
+
+        if (normalizedKey.endsWith('_PERMILLE')) {
+            return `${titleCase(key.replace(/_permille$/i, '').replaceAll('_', ' '))} (%)`;
+        }
+        if (normalizedKey.endsWith('_BYTES')) {
+            return `${titleCase(key.replace(/_bytes$/i, '').replaceAll('_', ' '))}`;
+        }
+        if (normalizedKey.endsWith('_TIME')) {
+            return `${titleCase(key.replace(/_time$/i, '').replaceAll('_', ' '))} Time`;
+        }
+        return titleCase(key.replaceAll('_', ' '));
+    }
+
+    function formatMetadataValue(key: string, value: unknown): string {
+        const normalizedKey = key.toUpperCase();
+        const numericValue = typeof value === 'number'
+            ? value
+            : typeof value === 'string' && value.trim() !== '' && !Number.isNaN(Number(value))
+                ? Number(value)
+                : null;
+
+        if (normalizedKey.endsWith('_PERMILLE') && numericValue !== null) {
+            return formatPercentFromPermille(numericValue);
+        }
+
+        if (normalizedKey.endsWith('_BYTES') && numericValue !== null) {
+            return bytesToSize(numericValue);
+        }
+
+        if (normalizedKey.endsWith('_TIME') && numericValue !== null) {
+            return formatDurationFromNanoseconds(numericValue);
+        }
+
+        return summarizeValue(value);
     }
 
     function getMetadataEntries(metadata: unknown): Array<[string, unknown]> {
@@ -260,8 +298,8 @@
                         <div class="mt-4 grid gap-3 md:grid-cols-2">
                             {#each metadataEntries as [key, value]}
                                 <div class="rounded-lg border border-gray-200 bg-gray-50 p-3">
-                                    <div class="text-xs uppercase text-gray-500">{key}</div>
-                                    <div class="mt-2 text-sm font-medium text-gray-900 break-words">{summarizeValue(value)}</div>
+                                    <div class="text-xs text-gray-500">{formatMetadataLabel(key)}</div>
+                                    <div class="mt-2 text-sm font-medium text-gray-900 break-words">{formatMetadataValue(key, value)}</div>
                                 </div>
                             {/each}
                         </div>

--- a/manager/src/routes/runs/[runId]/FinishedRun.svelte
+++ b/manager/src/routes/runs/[runId]/FinishedRun.svelte
@@ -1,123 +1,439 @@
 <script lang="ts">
     import { bytesToSize } from "$lib/helper";
+    import { authorizedFetch } from "$lib/auth.svelte";
+    import { config } from "$lib/state.svelte";
+    import { groupResultFiles, resultPathParam, sortResultFiles, type PreviewResponse } from "$lib/results";
+    import type { ClassifiedResultFile, ResultFile } from "$lib/types/ResultFile";
+    import type { RunResultSummary, RunState } from "$lib/types/RunState";
     import moment from "moment";
 
-    import { config } from "$lib/state.svelte";
-    import type { RunState } from "$lib/types/RunState";
-    import type { ResultFile } from "$lib/types/ResultFile";
     interface $$Props {
         run: RunState;
         files: ResultFile[];
+        initialTab?: 'overview' | 'outputs' | 'logs' | 'raw';
     }
 
-    let { run, files }: $$Props = $props();
-    let activeTab = $state('files'); // or 'files' or 'logs'
+    let { run, files, initialTab = 'overview' }: $$Props = $props();
+    let activeTab = $state(initialTab);
+    let showInternal = $state(false);
+    let selectedPreviewFile = $state<ClassifiedResultFile | null>(null);
+    let selectedPreview = $state<PreviewResponse | null>(null);
+    let previewError = $state('');
+    let previewLoading = $state(false);
+    let logsLoaded = $state(false);
+    let logPreview = $state<Record<string, PreviewResponse | null>>({});
+    let logErrors = $state<Record<string, string>>({});
+    let loadingLogs = $state(false);
 
-    async function downloadFile(fileName: string) {
-        const response = await fetch(`${config.apiServer}/runs/${run.id}/results/${fileName}`, {
-            headers: {
-                'X-User-ID': config.auth.user.id
+    const sortedFiles = $derived(sortResultFiles(files));
+    const summary = $derived.by((): RunResultSummary => {
+        if (run.result_summary) {
+            return run.result_summary;
+        }
+        return sortedFiles.reduce((acc, file) => {
+            if (file.kind === 'artifact') acc.artifact_count += 1;
+            if (file.kind === 'log') acc.log_count += 1;
+            if (file.kind === 'metadata') acc.metadata_count += 1;
+            if (file.kind === 'internal') acc.internal_count += 1;
+            acc.total_size += file.size;
+            return acc;
+        }, {
+            artifact_count: 0,
+            log_count: 0,
+            metadata_count: 0,
+            internal_count: 0,
+            total_size: 0
+        } as RunResultSummary);
+    });
+    const outputFiles = $derived(showInternal
+        ? sortedFiles.filter(file => file.kind !== 'log')
+        : sortedFiles.filter(file => file.kind === 'artifact')
+    );
+    const outputGroups = $derived(groupResultFiles(outputFiles));
+    const logFiles = $derived(
+        sortedFiles
+            .filter(file => file.kind === 'log')
+            .sort((left, right) => {
+                if (run.status === 'errored') {
+                    if (left.name === 'STDERR.log') return -1;
+                    if (right.name === 'STDERR.log') return 1;
+                }
+                return left.displayName.localeCompare(right.displayName);
+            })
+    );
+    const metadataEntries = $derived(getMetadataEntries(run.gotap_metadata));
+    const metadataMessages = $derived(extractMetadataMessages(run.gotap_metadata));
+    const compactMetadataJson = $derived(run.gotap_metadata ? JSON.stringify(run.gotap_metadata, null, 2) : '');
+
+    function setActiveTab(tab: 'overview' | 'outputs' | 'logs' | 'raw') {
+        activeTab = tab;
+        if (tab === 'logs') {
+            void ensureLogsLoaded();
+        }
+    }
+
+    function summarizeValue(value: unknown): string {
+        if (value === null || value === undefined) return 'n/a';
+        if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') return String(value);
+        if (Array.isArray(value)) return value.length === 0 ? '[]' : `${value.length} item${value.length === 1 ? '' : 's'}`;
+        if (typeof value === 'object') return `${Object.keys(value as Record<string, unknown>).length} field${Object.keys(value as Record<string, unknown>).length === 1 ? '' : 's'}`;
+        return String(value);
+    }
+
+    function getMetadataEntries(metadata: unknown): Array<[string, unknown]> {
+        if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+            return [];
+        }
+        return Object.entries(metadata as Record<string, unknown>);
+    }
+
+    function extractMetadataMessages(metadata: unknown): string[] {
+        if (!metadata || typeof metadata !== 'object') {
+            return [];
+        }
+
+        const entries = Object.entries(metadata as Record<string, unknown>);
+        const values: string[] = [];
+        for (const [key, value] of entries) {
+            const normalizedKey = key.toLowerCase();
+            if (!normalizedKey.includes('warning') && !normalizedKey.includes('message') && !normalizedKey.includes('error')) {
+                continue;
             }
-        });
+            if (typeof value === 'string' && value.trim()) {
+                values.push(value.trim());
+            } else if (Array.isArray(value)) {
+                for (const item of value) {
+                    if (typeof item === 'string' && item.trim()) {
+                        values.push(item.trim());
+                    }
+                }
+            }
+        }
+        return values;
+    }
+
+    async function downloadResult(file: ClassifiedResultFile) {
+        const response = await authorizedFetch(`${config.apiServer}/runs/${run.id}/results/${resultPathParam(file.relPath)}`);
+        if (!response.ok) {
+            throw new Error(await response.text());
+        }
         const blob = await response.blob();
-        const url = window.URL.createObjectURL(blob);
-        const a = document.createElement('a');
-        a.href = url;
-        a.download = fileName;
-        document.body.appendChild(a);
-        a.click();
-        window.URL.revokeObjectURL(url);
-        document.body.removeChild(a);
+        const url = URL.createObjectURL(blob);
+        const anchor = document.createElement('a');
+        anchor.href = url;
+        anchor.download = file.displayName;
+        document.body.appendChild(anchor);
+        anchor.click();
+        URL.revokeObjectURL(url);
+        document.body.removeChild(anchor);
+    }
+
+    async function fetchPreview(file: ClassifiedResultFile): Promise<PreviewResponse> {
+        const response = await authorizedFetch(`${config.apiServer}/runs/${run.id}/results/${resultPathParam(file.relPath)}/preview`);
+        if (!response.ok) {
+            throw new Error(await response.text());
+        }
+        return await response.json() as PreviewResponse;
+    }
+
+    async function openPreview(file: ClassifiedResultFile) {
+        selectedPreviewFile = file;
+        selectedPreview = null;
+        previewError = '';
+        previewLoading = true;
+
+        try {
+            const payload = await fetchPreview(file);
+            if (file.name.endsWith('.json')) {
+                try {
+                    payload.content = JSON.stringify(JSON.parse(payload.content), null, 2);
+                } catch (_error) {
+                    // Keep the original content if it is not valid JSON.
+                }
+            }
+            selectedPreview = payload;
+        } catch (error) {
+            previewError = error instanceof Error ? error.message : 'Failed to load preview';
+        } finally {
+            previewLoading = false;
+        }
+    }
+
+    async function ensureLogsLoaded() {
+        if (logsLoaded || loadingLogs) {
+            return;
+        }
+        loadingLogs = true;
+        try {
+            for (const logFile of logFiles) {
+                try {
+                    const payload = await fetchPreview(logFile);
+                    logPreview = { ...logPreview, [logFile.relPath]: payload };
+                    logErrors = { ...logErrors, [logFile.relPath]: '' };
+                } catch (error) {
+                    logErrors = {
+                        ...logErrors,
+                        [logFile.relPath]: error instanceof Error ? error.message : 'Failed to load log'
+                    };
+                    logPreview = { ...logPreview, [logFile.relPath]: null };
+                }
+            }
+            logsLoaded = true;
+        } finally {
+            loadingLogs = false;
+        }
     }
 </script>
 
 <div class="w-full">
-    <!-- Tab Navigation -->
     <div class="border-b border-gray-200">
-        <nav class="-mb-px flex" aria-label="Tabs">
-            <button
-                class={`
-                    w-24 py-2 px-3 text-center border-b-2 font-medium text-sm
-                    ${activeTab === 'files' 
-                        ? 'border-blue-500 text-blue-600'
-                        : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'}
-                `}
-                onclick={() => activeTab = 'files'}
-            >
-                Files
-            </button>
-            <button
-                class={`
-                    w-24 py-2 px-3 text-center border-b-2 font-medium text-sm
-                    ${activeTab === 'details' 
-                        ? 'border-blue-500 text-blue-600'
-                        : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'}
-                `}
-                onclick={() => activeTab = 'details'}
-            >
-                Details
-            </button>
-            <button
-                class={`
-                    w-24 py-2 px-3 text-center border-b-2 font-medium text-sm
-                    ${activeTab === 'logs' 
-                        ? 'border-blue-500 text-blue-600'
-                        : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'}
-                `}
-                onclick={() => activeTab = 'logs'}
-            >
-                Logs
-            </button>
+        <nav class="-mb-px flex flex-wrap gap-2" aria-label="Tabs">
+            {#each [
+                { id: 'overview', label: 'Overview' },
+                { id: 'outputs', label: 'Outputs' },
+                { id: 'logs', label: 'Logs' },
+                { id: 'raw', label: 'Raw' }
+            ] as tab}
+                <button
+                    class={`min-w-24 py-2 px-3 text-center border-b-2 font-medium text-sm ${
+                        activeTab === tab.id
+                            ? 'border-blue-500 text-blue-600'
+                            : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+                    }`}
+                    onclick={() => setActiveTab(tab.id as 'overview' | 'outputs' | 'logs' | 'raw')}
+                >
+                    {tab.label}
+                </button>
+            {/each}
         </nav>
     </div>
 
     <div class="mt-4">
-        {#if activeTab === 'details'}
-            <div>
-            <code>
-                <pre>{JSON.stringify(run, null, 2)}</pre>
-            </code>
+        {#if activeTab === 'overview'}
+            <div class="space-y-4">
+                <div class="grid gap-3 md:grid-cols-4">
+                    <div class="rounded-lg border border-gray-200 bg-white p-4">
+                        <div class="text-xs uppercase text-gray-500">Status</div>
+                        <div class="mt-2 text-lg font-semibold text-gray-900">{run.status}</div>
+                    </div>
+                    <div class="rounded-lg border border-gray-200 bg-white p-4">
+                        <div class="text-xs uppercase text-gray-500">Artifacts</div>
+                        <div class="mt-2 text-lg font-semibold text-gray-900">{summary.artifact_count}</div>
+                    </div>
+                    <div class="rounded-lg border border-gray-200 bg-white p-4">
+                        <div class="text-xs uppercase text-gray-500">Output size</div>
+                        <div class="mt-2 text-lg font-semibold text-gray-900">{bytesToSize(summary.total_size)}</div>
+                    </div>
+                    <div class="rounded-lg border border-gray-200 bg-white p-4">
+                        <div class="text-xs uppercase text-gray-500">Finished</div>
+                        <div class="mt-2 text-lg font-semibold text-gray-900">
+                            {run.finished_at ? moment(run.finished_at).fromNow() : 'Not finished'}
+                        </div>
+                    </div>
+                </div>
+
+                <div class="rounded-lg border border-gray-200 bg-white p-4">
+                    <div class="flex items-center justify-between">
+                        <div>
+                            <h2 class="text-lg font-semibold text-gray-900">gotap summary</h2>
+                            <p class="mt-1 text-sm text-gray-600">Structured metadata from `_metadata.json`, rendered defensively.</p>
+                        </div>
+                        {#if run.gotap_metadata}
+                            <span class="rounded-full bg-blue-100 px-2.5 py-1 text-xs font-medium text-blue-700">Metadata available</span>
+                        {:else}
+                            <span class="rounded-full bg-gray-100 px-2.5 py-1 text-xs font-medium text-gray-600">No metadata</span>
+                        {/if}
+                    </div>
+
+                    {#if metadataMessages.length > 0}
+                        <div class="mt-4 rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900">
+                            <div class="font-medium">Messages</div>
+                            <ul class="mt-2 list-disc pl-5">
+                                {#each metadataMessages as message}
+                                    <li>{message}</li>
+                                {/each}
+                            </ul>
+                        </div>
+                    {/if}
+
+                    {#if metadataEntries.length > 0}
+                        <div class="mt-4 grid gap-3 md:grid-cols-2">
+                            {#each metadataEntries as [key, value]}
+                                <div class="rounded-lg border border-gray-200 bg-gray-50 p-3">
+                                    <div class="text-xs uppercase text-gray-500">{key}</div>
+                                    <div class="mt-2 text-sm font-medium text-gray-900 break-words">{summarizeValue(value)}</div>
+                                </div>
+                            {/each}
+                        </div>
+                    {:else}
+                        <div class="mt-4 rounded-lg border border-dashed border-gray-300 p-4 text-sm text-gray-600">
+                            No structured gotap metadata was found for this run. Outputs and logs are still available below.
+                        </div>
+                    {/if}
+
+                    {#if compactMetadataJson}
+                        <div class="mt-4">
+                            <div class="text-sm font-medium text-gray-900">Compact JSON fallback</div>
+                            <pre class="mt-2 max-h-72 overflow-auto rounded-lg bg-gray-900 p-3 text-xs text-gray-100">{compactMetadataJson}</pre>
+                        </div>
+                    {/if}
+                </div>
             </div>
-        {:else if activeTab === 'files'}
-            <div>
-                <table class="w-full text-sm text-left">
-                    <thead class="text-xs uppercase bg-gray-50">
-                        <tr>
-                            <th scope="col" class="px-6 py-3">File name</th>
-                            <th scope="col" class="px-6 py-3">Size</th>
-                            <th scope="col" class="px-6 py-3">Last modified</th>
-                            <th scope="col" class="px-6 py-3">Action</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {#each files as file}
-                        <tr class="bg-white border-b border-b-gray-300 hover:bg-gray-50">
-                            <td class="px-6 py-4">{file.name}</td>
-                            <td class="px-6 py-4">{bytesToSize(file.size)}</td>
-                            <td class="px-6 py-4">{moment(file.lastModified).fromNow()}</td>
-                            <td class="px-6 py-4">
-                                <button 
-                                    onclick={() => downloadFile(file.name)}
-                                    class="text-blue-600 hover:text-blue-800 hover:cursor-pointer"
-                                    title="Download" 
-                                    aria-label="Download Result"
-                                >
-                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-                                    </svg>
-                                </button> 
-                            </td>
-                        </tr>
-                        {/each}
-                    </tbody>
-                </table>
+        {:else if activeTab === 'outputs'}
+            <div class="space-y-4">
+                <div class="flex items-center justify-between rounded-lg border border-gray-200 bg-white p-4">
+                    <div>
+                        <h2 class="text-lg font-semibold text-gray-900">Generated outputs</h2>
+                        <p class="mt-1 text-sm text-gray-600">Artifacts are shown by default. Internal helper files stay available behind a toggle.</p>
+                    </div>
+                    <label class="flex items-center gap-2 text-sm text-gray-700">
+                        <input type="checkbox" bind:checked={showInternal} class="rounded border-gray-300" />
+                        Show internal files
+                    </label>
+                </div>
+
+                {#if outputGroups.length === 0}
+                    <div class="rounded-lg border border-dashed border-gray-300 p-4 text-sm text-gray-600">
+                        No output files matched the current filter.
+                    </div>
+                {:else}
+                    {#each outputGroups as group}
+                        <div class="overflow-hidden rounded-lg border border-gray-200 bg-white">
+                            <div class="border-b border-gray-200 bg-gray-50 px-4 py-3 text-sm font-medium text-gray-900">
+                                {group.path === '.' ? 'root output folder' : group.path}
+                            </div>
+                            <div class="overflow-x-auto">
+                                <table class="w-full text-sm text-left">
+                                    <thead class="text-xs uppercase bg-gray-50 text-gray-500">
+                                        <tr>
+                                            <th scope="col" class="px-4 py-3">File</th>
+                                            <th scope="col" class="px-4 py-3">Relative path</th>
+                                            <th scope="col" class="px-4 py-3">Size</th>
+                                            <th scope="col" class="px-4 py-3">Modified</th>
+                                            <th scope="col" class="px-4 py-3">Actions</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {#each group.files as file}
+                                            <tr class="border-t border-gray-200">
+                                                <td class="px-4 py-3">
+                                                    <div class="font-medium text-gray-900">{file.displayName}</div>
+                                                    <div class="mt-1 text-xs text-gray-500 uppercase">{file.kind}</div>
+                                                </td>
+                                                <td class="px-4 py-3 font-mono text-xs text-gray-600">{file.relPath}</td>
+                                                <td class="px-4 py-3 text-gray-700">{bytesToSize(file.size)}</td>
+                                                <td class="px-4 py-3 text-gray-700">
+                                                    {file.lastModified ? moment(file.lastModified).fromNow() : 'Unknown'}
+                                                </td>
+                                                <td class="px-4 py-3">
+                                                    <div class="flex gap-3">
+                                                        {#if file.previewable}
+                                                            <button class="text-blue-600 hover:text-blue-800 hover:cursor-pointer" onclick={() => openPreview(file)}>
+                                                                Preview
+                                                            </button>
+                                                        {/if}
+                                                        <button class="text-gray-700 hover:text-gray-900 hover:cursor-pointer" onclick={() => downloadResult(file)}>
+                                                            Download
+                                                        </button>
+                                                    </div>
+                                                </td>
+                                            </tr>
+                                        {/each}
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                    {/each}
+                {/if}
             </div>
         {:else if activeTab === 'logs'}
-            <div>
-                <h2 class="text-lg font-semibold">StdOut</h2>
-                
-                <h2 class="text-lg font-semibold">StdErr</h2>
+            <div class="space-y-4">
+                {#if logFiles.length === 0}
+                    <div class="rounded-lg border border-dashed border-gray-300 p-4 text-sm text-gray-600">
+                        No `STDOUT.log` or `STDERR.log` files were found for this run.
+                    </div>
+                {:else}
+                    {#if loadingLogs}
+                        <div class="rounded-lg border border-gray-200 bg-white p-4 text-sm text-gray-600">
+                            Loading logs...
+                        </div>
+                    {/if}
+                    {#each logFiles as file}
+                        <div class="rounded-lg border border-gray-200 bg-white">
+                            <div class="flex items-center justify-between border-b border-gray-200 px-4 py-3">
+                                <div>
+                                    <div class="text-sm font-semibold text-gray-900">{file.displayName}</div>
+                                    <div class="text-xs text-gray-500">{file.relPath}</div>
+                                </div>
+                                <button class="text-sm text-gray-700 hover:text-gray-900 hover:cursor-pointer" onclick={() => downloadResult(file)}>
+                                    Download
+                                </button>
+                            </div>
+                            {#if logErrors[file.relPath]}
+                                <div class="p-4 text-sm text-red-600">{logErrors[file.relPath]}</div>
+                            {:else if logPreview[file.relPath]?.content}
+                                <div>
+                                    {#if logPreview[file.relPath]?.truncated}
+                                        <div class="border-b border-amber-200 bg-amber-50 px-4 py-2 text-xs text-amber-900">
+                                            Preview truncated to keep the UI responsive. Download the file for the full log.
+                                        </div>
+                                    {/if}
+                                    <pre class="max-h-[28rem] overflow-auto bg-gray-950 p-4 text-xs text-gray-100">{logPreview[file.relPath]?.content}</pre>
+                                </div>
+                            {:else}
+                                <div class="p-4 text-sm text-gray-600">Log file is empty.</div>
+                            {/if}
+                        </div>
+                    {/each}
+                {/if}
+            </div>
+        {:else if activeTab === 'raw'}
+            <div class="rounded-lg border border-gray-200 bg-white p-4">
+                <pre class="max-h-[32rem] overflow-auto rounded-lg bg-gray-950 p-4 text-xs text-gray-100">{JSON.stringify(run, null, 2)}</pre>
             </div>
         {/if}
     </div>
+
+    {#if selectedPreviewFile}
+        <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/45 p-4">
+            <div class="max-h-[90vh] w-full max-w-5xl overflow-hidden rounded-xl bg-white shadow-2xl">
+                <div class="flex items-center justify-between border-b border-gray-200 px-5 py-4">
+                    <div>
+                        <div class="text-lg font-semibold text-gray-900">{selectedPreviewFile.displayName}</div>
+                        <div class="text-xs text-gray-500">{selectedPreviewFile.relPath}</div>
+                    </div>
+                    <button class="text-sm text-gray-600 hover:text-gray-900 hover:cursor-pointer" onclick={() => {
+                        selectedPreviewFile = null;
+                        selectedPreview = null;
+                        previewError = '';
+                    }}>
+                        Close
+                    </button>
+                </div>
+
+                <div class="p-5">
+                    {#if previewLoading}
+                        <div class="text-sm text-gray-600">Loading preview...</div>
+                    {:else if previewError}
+                        <div class="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700">{previewError}</div>
+                    {:else if selectedPreview}
+                        <div class="space-y-3">
+                            <div class="flex items-center justify-between text-xs text-gray-500">
+                                <div>{selectedPreview.mimeType} · {selectedPreview.encoding}</div>
+                                <button class="text-sm text-gray-700 hover:text-gray-900 hover:cursor-pointer" onclick={() => downloadResult(selectedPreviewFile!)}>
+                                    Download file
+                                </button>
+                            </div>
+                            {#if selectedPreview.truncated}
+                                <div class="rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900">
+                                    Preview truncated to the first 64 KB. Download the file to inspect the full contents.
+                                </div>
+                            {/if}
+                            <pre class="max-h-[60vh] overflow-auto rounded-lg bg-gray-950 p-4 text-xs text-gray-100">{selectedPreview.content}</pre>
+                        </div>
+                    {/if}
+                </div>
+            </div>
+        </div>
+    {/if}
 </div>

--- a/manager/src/routes/specs/+page.svelte
+++ b/manager/src/routes/specs/+page.svelte
@@ -41,6 +41,10 @@
             return `${authors[0]} et al. (${repo})`;
         }
     }
+
+    function getSpecHref(specId: string): string {
+        return `/manager/specs/${encodeURIComponent(specId)}`;
+    }
 </script>
 
 <div class="p-4">
@@ -54,10 +58,10 @@
                 class="block cursor-pointer" 
                 role="button"
                 tabindex="0"
-                onclick={() => goto(`/manager/specs/${spec.id}`)}
+                onclick={() => goto(getSpecHref(spec.id))}
                 onkeydown={(e: KeyboardEvent) => {
                     if (e.key === 'Enter') {
-                        goto(`/manager/specs/${spec.id}`);
+                        goto(getSpecHref(spec.id));
                     }
                 }}
             >

--- a/manager/src/routes/specs/[specId]/+page.svelte
+++ b/manager/src/routes/specs/[specId]/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { authorizedFetch } from "$lib/auth.svelte";
     import DataInput from "$lib/components/DataInput.svelte";
     import ParameterInput from "$lib/components/ParameterInput.svelte";
     import type { RemoteFile } from "$lib/types/TempFile";
@@ -18,6 +19,9 @@
     $inspect(dataValues);
 
     let currentTab: 'parameters' | 'cli' | 'citation' = $state('parameters');
+    let submitError = $state('');
+    let submitValidationErrors = $state<string[]>([]);
+    let submitPending = $state(false);
 
     function updateParameterValues(name: string, value: any) {
         parameterValues = {...parameterValues, [name]: value};
@@ -42,10 +46,13 @@
     let dockerImage = $derived(spec.id.split('::')[0]);
     let toolName = $derived(spec.id.split('::')[1]);
 
-    function startRun() {
+    async function startRun() {
+        submitError = '';
+        submitValidationErrors = [];
         const [dockerImage, toolName, ...o] = spec.id.split('::');
         if (!dockerImage || !toolName || spec.name !== toolName || o.length > 0) {
             console.error(`Invalid tool slug: ${spec.id}`) 
+            submitError = `Invalid tool slug: ${spec.id}`;
             return 
         }
 
@@ -56,19 +63,55 @@
             data: Object.fromEntries(Object.entries(dataValues).map(([name, conf]) => ([name, conf.path])))
         })
 
-        fetch(`${config.apiServer}/runs`, {
-            method: 'POST',
-            headers: {
-                'Accept': 'application/json',
-                'Content-Type': 'application/json'
-            },
-            body: JSON.stringify(payload)
-        })
-        .then(res => res.json())
-        .then(response => { 
-            console.log(response);
-            goto('/manager/runs');
-        })
+        submitPending = true;
+        try {
+            const response = await authorizedFetch(`${config.apiServer}/runs`, {
+                method: 'POST',
+                headers: {
+                    'Accept': 'application/json',
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify(payload)
+            });
+
+            const responseText = await response.text();
+            let responseBody: Record<string, unknown> | null = null;
+            if (responseText) {
+                try {
+                    responseBody = JSON.parse(responseText) as Record<string, unknown>;
+                } catch (_error) {
+                    responseBody = null;
+                }
+            }
+
+            if (!response.ok) {
+                const message = typeof responseBody?.message === 'string'
+                    ? responseBody.message
+                    : `Failed to create run (${response.status})`;
+                submitError = message;
+                if (Array.isArray(responseBody?.errors)) {
+                    submitValidationErrors = responseBody.errors
+                        .map((entry) => typeof entry?.message === 'string' ? entry.message : JSON.stringify(entry))
+                        .filter((entry): entry is string => Boolean(entry));
+                }
+                console.error("Failed to create run", response.status, responseBody ?? responseText);
+                return;
+            }
+
+            const runId = responseBody?.id;
+            if (typeof runId === 'number') {
+                goto(`/manager/runs/${runId}`);
+                return;
+            }
+
+            submitError = 'Run was created, but the server did not return a valid run id.';
+            console.error("Unexpected create run response", responseBody ?? responseText);
+        } catch (error) {
+            submitError = error instanceof Error ? error.message : 'Failed to create run';
+            console.error("Failed to create run", error);
+        } finally {
+            submitPending = false;
+        }
     }
 </script>
 
@@ -156,9 +199,19 @@
 
 </div>
 {#if allValid}
-<button class="w-full px-3 py-2 bg-green-500 text-white rounded-lg shadow-md hover:bg-green-600 transition-colors cursor-pointer" onclick={startRun}>
-    Create
+{#if submitError}
+<div class="mb-3 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+    <div>{submitError}</div>
+    {#if submitValidationErrors.length > 0}
+    <ul class="mt-2 list-disc pl-5">
+        {#each submitValidationErrors as validationError}
+        <li>{validationError}</li>
+        {/each}
+    </ul>
+    {/if}
+</div>
+{/if}
+<button class="w-full px-3 py-2 bg-green-500 text-white rounded-lg shadow-md hover:bg-green-600 transition-colors cursor-pointer disabled:cursor-not-allowed disabled:bg-green-300" onclick={startRun} disabled={submitPending}>
+    {submitPending ? 'Creating...' : 'Create'}
 </button>
 {/if}
-
-

--- a/manager/src/routes/specs/[specId]/+page.ts
+++ b/manager/src/routes/specs/[specId]/+page.ts
@@ -2,7 +2,8 @@ import type { PageLoad } from "./$types";
 
 export const load: PageLoad = ({ params, parent }) => {
     return parent().then(({ specs }) => {
-        const spec = specs.find(spec => spec.id === params.specId);
+        const specId = decodeURIComponent(params.specId);
+        const spec = specs.find(spec => spec.id === specId);
         return { spec };
     });
 };

--- a/manager/src/routes/specs/[specId]/CLInfo.svelte
+++ b/manager/src/routes/specs/[specId]/CLInfo.svelte
@@ -25,11 +25,17 @@
 
     let {id, name, image, parameterValues, dataValues}: CliProps = $props();
 
+    let payloadData = $derived(
+        Object.fromEntries(
+            Object.entries(dataValues).map(([key, value]) => [key, value?.path])
+        )
+    );
+
     let payload = $derived({
         name: name,
         docker_image: image,
         parameters: parameterValues,
-        data: dataValues,
+        data: payloadData,
     })
 
     let bashCode = $derived(`run_id=$(curl -X POST -H "Content-Type: application/json" -d '${JSON.stringify(payload).replace(/'/g, "'\\''")}' ${config.apiServer}/runs | jq -r '.id')
@@ -46,7 +52,7 @@ payload = {
 response = httpx.post("${config.apiServer}/runs", json=payload).json()
 run_id = response.get('id')
 if run_id:
-    run_data = httpx.get(f"{config.apiServer}/runs/{run_id}/start").json()
+    run_data = httpx.post(f"{config.apiServer}/runs/{run_id}/start").json()
     print(run_data['status'])
 else:
     print("Failed to create tool run")


### PR DESCRIPTION
## Summary
- add exact-path result resolution and a preview API for common text-based outputs
- surface gotap metadata and grouped outputs in the run detail manager UI, including inline preview and logs
- add run list output badges plus quick actions for finished results and errored logs
- include the follow-up manager flow and embedded asset fixes on top of main

## Rebuild Verification
- GOCACHE=/tmp/gocache GOPROXY=off go build ./...
- GOCACHE=/tmp/gocache go test ./...
- npm run check
- npm run build

## Acceptance Criteria
- finished runs show gotap metadata in a readable Overview tab instead of only raw JSON
- outputs are grouped by relative path, internal/helper files are hidden by default, and all files remain downloadable
- common text outputs (.json, .txt, .log, .md, .csv) can be previewed inline via the new preview endpoint
- errored runs expose stdout/stderr logs in the Logs tab and from the runs list via a View error action
- run list rows show output summary badges, including artifact counts and gotap presence when metadata exists
- result download and preview use exact relPath identifiers so duplicate basenames in nested folders resolve correctly

## Notes
- this PR intentionally excludes the untested MCP branch work and only carries the clean gotap/UI fixes